### PR TITLE
Note that PHP before 7.3 will fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Tested with PHP 7.3 and MySQL 5.6.
 
+Versions earlier than PHP 7.3 will not work.
+
 ## Deployment
 
 - Copy this repository to a webserver


### PR DESCRIPTION
trailing comma in function and method calls support is mandatory

"Tested with" does not imply that earlier versions will fail. I managed to test this and confirm that earlier versions are doomed.