### PR TITLE
Better log in cases where connection fails

### DIFF
--- a/classes/ChangesetElementIdsFetcher.class.php
+++ b/classes/ChangesetElementIdsFetcher.class.php
@@ -43,6 +43,9 @@ class ChangesetElementIdsFetcher
         }
         $response->body = curl_exec($curl);
         $response->code = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+        if($response->code == 0) {
+	        throw new Exception('query failed without receiving response, function returned code ' . $response->code . ' curl reports ' . curl_error($curl));
+        }
         curl_close($curl);
         return $response;
     }

--- a/classes/ChangesetModifiedElementsFetcher.class.php
+++ b/classes/ChangesetModifiedElementsFetcher.class.php
@@ -43,6 +43,9 @@ class ChangesetModifiedElementsFetcher
         }
         $response->body = curl_exec($curl);
         $response->code = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+        if($response->code == 0) {
+	        throw new Exception('query failed without receiving response, function returned code ' . $response->code . ' curl reports ' . curl_error($curl));
+        }
         curl_close($curl);
         return $response;
     }

--- a/classes/ChangesetsFetcher.class.php
+++ b/classes/ChangesetsFetcher.class.php
@@ -62,6 +62,9 @@ class ChangesetsFetcher
         }
         $response->body = curl_exec($curl);
         $response->code = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+        if($response->code == 0) {
+	        throw new Exception('query failed without receiving response, function returned code ' . $response->code . ' curl reports ' . curl_error($curl));
+        }
         curl_close($curl);
         return $response;
     }


### PR DESCRIPTION
fixes #18

No longer claims that query returned HTTP code 0 which is confusing and untrue

I think that better error reporting is sufficient as for example `php update_users.php` appears to be able to continue after it is run again after crashing.

![screen](https://user-images.githubusercontent.com/899988/147291307-61fd6afc-82e8-4d21-939b-583047cb2def.png)
